### PR TITLE
Update sidenav links to match designs (#0)

### DIFF
--- a/src/App/components/Layout/components/SideNav/SideNav.module.scss
+++ b/src/App/components/Layout/components/SideNav/SideNav.module.scss
@@ -4,21 +4,24 @@
   background-color: #474746;
   display: flex;
   flex-direction: column;
-  align-items: left;
   padding: 20px 0 0 20px;
 }
 
-.image {
-  padding-bottom: 60px;
+.logo {
+  padding-bottom: 30px;
   align-self: flex-start;
 }
 
+.linkIcon {
+  display: inline-block;
+}
+
 .inactiveLink {
-  padding: 20px 0;
+  padding: 10px 0;
   text-decoration: none;
   color: white;
 
-  .icon {
+  .linkIcon {
     margin-right: 5px;
     filter: invert(100%);
   }
@@ -27,7 +30,7 @@
 .activeLink {
   color: rgb(191, 92, 88);
 
-  .icon {
+  .linkicon {
     // https://codepen.io/sosuke/pen/Pjoqqp
     filter: invert(38%) sepia(30%) saturate(1289%) hue-rotate(314deg)
       brightness(104%) contrast(68%);

--- a/src/App/components/Layout/components/SideNav/SideNav.tsx
+++ b/src/App/components/Layout/components/SideNav/SideNav.tsx
@@ -29,7 +29,7 @@ export default function SideNav(): JSX.Element {
 
   return (
     <div className={styles.wrapper}>
-      <img src={bitoviLogo} alt="Bitovi" className={styles.image} />
+      <img src={bitoviLogo} alt="Bitovi" className={styles.logo} />
 
       {links.map(({ exact, link, label, icon }) => (
         <NavLink
@@ -39,7 +39,7 @@ export default function SideNav(): JSX.Element {
           activeClassName={styles.activeLink}
           className={styles.inactiveLink}
         >
-          <img src={icon} alt={label} className={styles.icon} />
+          <img src={icon} alt={label} className={styles.linkIcon} />
           {label}
         </NavLink>
       ))}


### PR DESCRIPTION
- Icon and text are on the same line
- Reduce space between links and logo

<img width="1531" alt="Screen Shot 2021-11-17 at 12 44 10 PM" src="https://user-images.githubusercontent.com/724877/142253849-eccee381-ad67-4cfc-ba22-4f253e96c83a.png">
