### PR TITLE
fix: adds sub-date with day for quarter labels

### DIFF
--- a/src/pages/Dashboard/components/ReportTable/TableHeader/TableHeader.tsx
+++ b/src/pages/Dashboard/components/ReportTable/TableHeader/TableHeader.tsx
@@ -37,7 +37,8 @@ export default function TableHeader({
 
             {/* Sub Heading */}
             <Center height={4} flex={1} justifyContent="start">
-              {type === TimescaleType.month && (
+              {(type === TimescaleType.month ||
+                type === TimescaleType.quarter) && (
                 <Text color={"#718096"}>{format(startDate, "MMM do")}</Text>
               )}
             </Center>


### PR DESCRIPTION
[STAF-22](https://bitovi.atlassian.net/browse/STAF-22)

![Screen Shot 2021-12-13 at 10 51 31 AM](https://user-images.githubusercontent.com/46300738/145844444-e26c7dfd-62a6-4998-8dd7-1cfed52ca983.png)

Timeline adjustment: shows month and day under quarter labels