### PR TITLE
STAF-161: fix employee delete against service layer

### DIFF
--- a/src/components/ConfirmationModal/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.tsx
@@ -1,5 +1,8 @@
 import { HStack, Text } from "@chakra-ui/layout";
 import {
+  Alert,
+  AlertIcon,
+  AlertTitle,
   Modal,
   ModalBody,
   ModalCloseButton,
@@ -18,6 +21,7 @@ interface ConfirmationModalProps {
   message: string;
   closeText: string;
   confirmText: string;
+  confirmLoadingText?: string;
   error?: string;
   isLoading?: boolean;
   confirmButtonVariant?: ButtonVariant;
@@ -33,6 +37,7 @@ export default function ConfirmationModal({
   message,
   closeText,
   confirmText,
+  confirmLoadingText,
   error,
   isLoading,
   confirmButtonVariant = "primary",
@@ -51,13 +56,13 @@ export default function ConfirmationModal({
         <ModalCloseButton />
         <ModalHeader>{title}</ModalHeader>
         <ModalBody>
-          {/* // TODO: Should have a common error component across the application */}
-          {error && (
-            <Text mb={4} color="red">
-              {error}
-            </Text>
-          )}
           <Text textStyle="modal.text">{message}</Text>
+          {error && (
+            <Alert status="error" mt="15px">
+              <AlertIcon />
+              <AlertTitle mr={2}>{error}</AlertTitle>
+            </Alert>
+          )}
         </ModalBody>
         <ModalFooter>
           <HStack flexGrow={1} justifyContent="flex-end">
@@ -74,6 +79,7 @@ export default function ConfirmationModal({
               onClick={onConfirm}
               variant={confirmButtonVariant}
               aria-label="confirm button"
+              loadingText={confirmLoadingText}
             >
               {confirmText}
             </Button>

--- a/src/mocks/baseMocks/requestCreator.ts
+++ b/src/mocks/baseMocks/requestCreator.ts
@@ -160,14 +160,13 @@ export default function requestCreator<Resource extends BaseResource>(
           return res(
             ctx.status(404),
             ctx.json({
-              error: `Project ${id} not found.`,
+              error: `Resource with id: ${id} not found.`,
             }),
           );
         }
 
         await store.destroyData(resourceToDelete);
-
-        return res(ctx.status(200), ctx.json({}));
+        return res(ctx.status(204));
       },
     ),
   };

--- a/src/pages/Employees/components/EmployeeTable/EmployeeTable.test.tsx
+++ b/src/pages/Employees/components/EmployeeTable/EmployeeTable.test.tsx
@@ -1,8 +1,10 @@
-import { render, screen } from "@testing-library/react";
+import noop from "lodash/noop";
+import { render, screen, within, act, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { employees } from "../../../../mocks/fixtures";
 import EmployeeTable from "./EmployeeTable";
 
-describe("Components/Layout", () => {
+describe("EmployeeTable", () => {
   it("has an 'empty' state", async () => {
     render(
       <EmployeeTable
@@ -26,12 +28,93 @@ describe("Components/Layout", () => {
       />,
     );
 
-    // wait for the first row
-    expect(screen.getByText(employees[0].name)).toBeInTheDocument();
-
-    // check the rest of the rows
-    // expect(screen.getByDisplayValue(employees[1].name)).toBeInTheDocument();
-    // expect(screen.getByDisplayValue(employees[2].name)).toBeInTheDocument();
-    // expect(screen.getByDisplayValue(employees[3].name)).toBeInTheDocument();
+    employees.forEach((employee) => {
+      expect(screen.getByText(employee.name)).toBeInTheDocument();
+    });
   });
+
+  it("should not retain error message in delete confirmation modal", async () => {
+    const deferred = makeDeferred();
+
+    const { findByRole, findAllByRole } = render(
+      <EmployeeTable
+        updateEmployee={() => Promise.resolve()}
+        destroyEmployee={(id) => deferred.promise}
+        employees={employees}
+        skills={[]}
+      />,
+    );
+
+    // click delete icon on the employee table row
+    const employeeRows = await findAllByRole("row");
+    const employeeToDelete = employeeRows[1];
+    const deleteButton = await within(employeeToDelete).findByRole("button", {
+      name: "Delete Member",
+    });
+    userEvent.click(deleteButton);
+
+    // make sure the confirmation modal shows up
+    const confirmationModal = await findByRole("dialog");
+    const confirmButton = await within(confirmationModal).findByLabelText(
+      /confirm button/i,
+    );
+    userEvent.click(confirmButton);
+
+    // make sure the CTA button has the loading state once it has been clicked
+    expect(confirmButton).toHaveAttribute("data-loading");
+    await within(confirmationModal).findByText(/deleting team member/i);
+
+    // simulate an error from the delete employee endpoint
+    act(() => {
+      deferred.reject(new Error("Uh-oh, something bad happened"));
+    });
+
+    // check the button loading state was removed and the error
+    await waitFor(() => {
+      expect(confirmButton).not.toHaveAttribute("data-loading");
+    });
+    const errorAlert = await within(confirmationModal).findByRole("alert");
+    await within(errorAlert).findByText(/something bad happened/);
+
+    // Dismiss the confirmation modal
+    const cancelButton = within(confirmationModal).getByRole("button", {
+      name: "Cancel",
+    });
+    userEvent.click(cancelButton);
+    await waitFor(() => {
+      expect(confirmationModal).not.toBeInTheDocument();
+    });
+
+    // Try to delete the employee again
+    userEvent.click(deleteButton);
+    const secondConfirmationModal = await findByRole("dialog");
+
+    // make sure the previous error alert does not persist
+    const secondErrorAlert = await within(secondConfirmationModal).queryByRole(
+      "alert",
+    );
+    expect(secondErrorAlert).toBeNull();
+
+    // the confirm button loading state should not persist
+    const secondConfirmButton = await within(confirmationModal).findByLabelText(
+      /confirm button/i,
+    );
+    expect(secondConfirmButton).not.toHaveAttribute("data-loading");
+  });
+
+  function makeDeferred() {
+    let resolve = noop;
+    let reject = noop;
+
+    const promise = new Promise<void>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+
+    return {
+      resolve,
+      reject,
+      promise,
+    };
+  }
 });

--- a/src/services/api/restBuilder/fetcher/fetcher.ts
+++ b/src/services/api/restBuilder/fetcher/fetcher.ts
@@ -33,5 +33,9 @@ export default async function fetcher(
     );
   }
 
+  // 204 responses do not include content, calling response.json() throws an
+  // exception.
+  if (response.status === 204) return {};
+
   return await response.json();
 }

--- a/src/theme/components/button.ts
+++ b/src/theme/components/button.ts
@@ -51,6 +51,11 @@ const button: StyleConfig = {
       lineHeight: "24px",
       fontSize: "16px",
       fontWeight: "600",
+      _hover: {
+        _disabled: {
+          backgroundColor: "red.500",
+        },
+      },
     },
   },
   sizes: {


### PR DESCRIPTION
- Fix disabled button dissapering on hover
- Update confirmation modal error state to match designs
- Update confirmation modal to match CTA click design
- Prevent fetcher from throwing when trying to parse the "No Content" response body

> The delete team member workflow is broken against the mock service layer, we'll fix that in a separate PR

<img width="1219" alt="Screen Shot 2022-01-11 at 3 55 47 PM" src="https://user-images.githubusercontent.com/724877/149031644-e40286f0-cb3e-4bc1-b9b2-19ab1d2941eb.png">

<img width="1219" alt="Screen Shot 2022-01-11 at 3 56 14 PM" src="https://user-images.githubusercontent.com/724877/149031669-d8371a15-346b-47c4-8018-8194fdae57c0.png">

<img width="1219" alt="Screen Shot 2022-01-11 at 3 56 39 PM" src="https://user-images.githubusercontent.com/724877/149031690-5ff00fca-3b97-447c-961e-0ca17f9ddf91.png">


