### PR TITLE
staf-80: add breadcrumbs to employees page

### DIFF
--- a/src/pages/Employees/Employees.test.tsx
+++ b/src/pages/Employees/Employees.test.tsx
@@ -57,7 +57,7 @@ describe("Pages/Employees", () => {
 
     const employeesBreadcrumb = queryByTestId("employeesBreadcrumb");
 
-    expect(employeesBreadcrumb?.tagName.toLowerCase()).toBe('span');
+    expect(employeesBreadcrumb?.tagName.toLowerCase()).toBe("span");
   });
 
   it("Creates employee", async () => {

--- a/src/pages/Employees/Employees.test.tsx
+++ b/src/pages/Employees/Employees.test.tsx
@@ -34,6 +34,32 @@ describe("Pages/Employees", () => {
     ).toBeDefined();
   });
 
+  it("renders breadcrumbs", () => {
+    const { queryByTestId } = render(<EmployeesWrapper />);
+
+    const homeBreadcrumb = queryByTestId("homeBreadcrumb");
+    const employeesBreadcrumb = queryByTestId("employeesBreadcrumb");
+
+    expect(homeBreadcrumb).toBeInTheDocument();
+    expect(employeesBreadcrumb).toBeInTheDocument();
+  });
+
+  it("renders home breadcrumb with the correct link", () => {
+    const { queryByTestId } = render(<EmployeesWrapper />);
+
+    const homeBreadcrumb = queryByTestId("homeBreadcrumb");
+
+    expect(homeBreadcrumb?.closest("a")).toHaveAttribute("href", "/");
+  });
+
+  it("renders team member breadcrumb as span", () => {
+    const { queryByTestId } = render(<EmployeesWrapper />);
+
+    const employeesBreadcrumb = queryByTestId("employeesBreadcrumb");
+
+    expect(employeesBreadcrumb?.tagName.toLowerCase()).toBe('span');
+  });
+
   it("Creates employee", async () => {
     render(<EmployeesWrapper />);
 

--- a/src/pages/Employees/Employees.tsx
+++ b/src/pages/Employees/Employees.tsx
@@ -1,5 +1,7 @@
 import { Suspense, useState } from "react";
 import { Box, Flex, Text } from "@chakra-ui/layout";
+import { Breadcrumb, BreadcrumbItem, BreadcrumbLink } from "@chakra-ui/react";
+import { ChevronRightIcon } from "@chakra-ui/icons";
 import {
   Employee,
   useEmployees as useEmployeesDefault,
@@ -81,6 +83,26 @@ export function Employees({
         onSave={addNewEmployee}
         skills={skills}
       />
+
+      <Breadcrumb
+        spacing="8px"
+        marginBottom="16px"
+        fontSize="14px"
+        color="gray.500"
+        separator={<ChevronRightIcon />}
+      >
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/" data-testid="homeBreadcrumb">
+            Home
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+
+        <BreadcrumbItem isCurrentPage color="gray.800">
+          <BreadcrumbLink data-testid="employeesBreadcrumb" cursor="default" _hover={{ textDecoration: 'none' }}>
+            Team Members
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+      </Breadcrumb>
 
       <Flex
         width="full"

--- a/src/pages/Employees/Employees.tsx
+++ b/src/pages/Employees/Employees.tsx
@@ -98,7 +98,11 @@ export function Employees({
         </BreadcrumbItem>
 
         <BreadcrumbItem isCurrentPage color="gray.800">
-          <BreadcrumbLink data-testid="employeesBreadcrumb" cursor="default" _hover={{ textDecoration: 'none' }}>
+          <BreadcrumbLink
+            data-testid="employeesBreadcrumb"
+            cursor="default"
+            _hover={{ textDecoration: "none" }}
+          >
             Team Members
           </BreadcrumbLink>
         </BreadcrumbItem>


### PR DESCRIPTION
Added breadcrumbs to navigate to home and show current page as team members page

![image](https://user-images.githubusercontent.com/13068398/150155552-591be134-7776-43ac-b8e7-9c40e413ce98.png)
