### PR TITLE
STAF-210: Fix create / update employee fixture endpoint

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import { ChakraProvider } from "@chakra-ui/react";
 import App from "./App";
 import theme from "./theme";
 
+// Remember to disable mocks before creating a pull request
 // import "./setupMocks";
 import "./theme/fonts/styles.css";
 

--- a/src/mocks/baseMocks/requestCreator.ts
+++ b/src/mocks/baseMocks/requestCreator.ts
@@ -112,7 +112,8 @@ export default function requestCreator<Resource extends BaseResource>(
 
         await store.createData(item);
 
-        return res(ctx.status(201), ctx.json({ data: item }));
+        const included = await getIncluded([item]);
+        return res(ctx.status(201), ctx.json({ data: item, included }));
       },
     ),
     update: rest.patch<
@@ -143,10 +144,12 @@ export default function requestCreator<Resource extends BaseResource>(
         );
       }
 
+      const included = await getIncluded([updatedItem]);
       return res(
         ctx.status(201),
         ctx.json({
           data: updatedItem,
+          included,
         }),
       );
     }),


### PR DESCRIPTION
Both mock endpoints were missing the JSON:API `included` property in the response. This prevents the serializer from fully hydrating the relationships objects on each request.

## Before:
![2022-01-24 08 00 03](https://user-images.githubusercontent.com/724877/150790225-acd23d96-f5a5-4134-97b4-675e22312b9b.gif)

## After 
![2022-01-24 08 02 21](https://user-images.githubusercontent.com/724877/150790345-6f034302-3ebc-4166-8f8e-518c5d5c86d6.gif)


