### PR TITLE
STAF-60: Employee Modal Cleanup

### DIFF
--- a/src/pages/Employees/Employees.tsx
+++ b/src/pages/Employees/Employees.tsx
@@ -9,7 +9,7 @@ import {
 import EmployeeTable from "./components/EmployeeTable";
 import { EmployeeCardSkeleton } from "./components/EmployeeCard/EmployeeCard";
 import Button from "../../components/Button";
-import EmployeeModal from "./components/EmployeeModal";
+import EmployeeModal from "./components/EmployeeModal/EmployeeModal";
 import EmployeesBreadcrumbs from "./components/EmployeesBreadcrumbs";
 
 interface EmployeesProps {

--- a/src/pages/Employees/components/EmployeeModal/EmployeeModal.test.tsx
+++ b/src/pages/Employees/components/EmployeeModal/EmployeeModal.test.tsx
@@ -159,7 +159,7 @@ describe("EmployeeModal", () => {
     expect(addButton).not.toHaveAttribute("aria-disabled", "true");
 
     userEvent.click(addButton);
-    await findByText(/saving/i);
+    await findByText(/Adding team member/i);
 
     expect(onSave).toHaveBeenCalledTimes(1);
     const employeeToSave = onSave.mock.calls[0][0];

--- a/src/pages/Employees/components/EmployeeModal/EmployeeModal.test.tsx
+++ b/src/pages/Employees/components/EmployeeModal/EmployeeModal.test.tsx
@@ -86,7 +86,7 @@ describe("EmployeeModal", () => {
 
     // Save button will be in "pending" state when clicked
     await waitFor(() => {
-      expect(getByText("Saving")).toBeInTheDocument();
+      expect(getByText("Adding team member")).toBeInTheDocument();
     });
   });
 

--- a/src/pages/Employees/components/EmployeeModal/EmployeeModal.tsx
+++ b/src/pages/Employees/components/EmployeeModal/EmployeeModal.tsx
@@ -252,7 +252,7 @@ function getSubmitButtonProps({
     return {
       isLoading: true,
       isDisabled: true,
-      loadingText: "Saving",
+      loadingText: "Adding team member",
     };
   }
 


### PR DESCRIPTION
- Changed the loading text for the `EmployeeModal` from `Saving` to `Adding team member` to match Figma design.
- Refactored corresponding test