### PR TITLE
Staf 304 needed details are out of order and duplicating within a specific date

### DIFF
--- a/src/pages/Dashboard/components/ReportTable/ReportTable.stories.tsx
+++ b/src/pages/Dashboard/components/ReportTable/ReportTable.stories.tsx
@@ -1,4 +1,4 @@
-import type { ComponentStory, ComponentMeta } from "@storybook/react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
 
 import { useState } from "react";
 import { Flex } from "@chakra-ui/layout";
@@ -6,6 +6,7 @@ import { Flex } from "@chakra-ui/layout";
 import { DatePicker } from "../../../../components/DatePicker";
 import Text from "../../../../components/Typography/Heading";
 import { ReportTable } from "./ReportTable";
+import { MemoryRouter } from "react-router-dom";
 
 export default {
   title: "Components/ReportTable",
@@ -16,7 +17,7 @@ export const Basic: ComponentStory<typeof ReportTable> = (args) => {
   const [date, setDate] = useState(new Date());
 
   return (
-    <>
+    <MemoryRouter>
       <Text variant="h2" my="6">
         Select a Date to Change the Timeline.
       </Text>
@@ -25,6 +26,6 @@ export const Basic: ComponentStory<typeof ReportTable> = (args) => {
       <hr />
       <Flex my="6" />
       <ReportTable date={date} />
-    </>
+    </MemoryRouter>
   );
 };

--- a/src/pages/Dashboard/components/ReportTable/ReportTable.stories.tsx
+++ b/src/pages/Dashboard/components/ReportTable/ReportTable.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import type { ComponentStory, ComponentMeta } from "@storybook/react";
 
 import { useState } from "react";
 import { Flex } from "@chakra-ui/layout";

--- a/src/pages/Dashboard/components/ReportTable/TableRow/TableRow.test.tsx
+++ b/src/pages/Dashboard/components/ReportTable/TableRow/TableRow.test.tsx
@@ -8,15 +8,18 @@ import theme from "../../../../../theme";
 import TableRow from "./TableRow";
 describe("Pages/Dashboard/ReportTable/TableRow", () => {
   it("renders the first TableRow component", async () => {
-      const {result} = renderHook(()=>useProjection(new Date(), skills));
+    const { result } = renderHook(() => useProjection(new Date(), skills));
     render(
-        <MemoryRouter>
-            <StylesProvider value={theme}>
-                <table>
-                    <TableRow skill={skills[0]} projections={result.current.skillsWithProjection[0].projections} />
-                </table>
-            </StylesProvider>
-        </MemoryRouter>
+      <MemoryRouter>
+        <StylesProvider value={theme}>
+          <table>
+            <TableRow
+              skill={skills[0]}
+              projections={result.current.skillsWithProjection[0].projections}
+            />
+          </table>
+        </StylesProvider>
+      </MemoryRouter>,
     );
     expect(await screen.findByText(skills[0].name)).toBeInTheDocument();
   });

--- a/src/pages/Dashboard/components/ReportTable/TableRow/TableRow.test.tsx
+++ b/src/pages/Dashboard/components/ReportTable/TableRow/TableRow.test.tsx
@@ -1,0 +1,23 @@
+import { StylesProvider } from "@chakra-ui/react";
+import { render, screen } from "@testing-library/react";
+import { renderHook } from "@testing-library/react-hooks";
+import { MemoryRouter } from "react-router-dom";
+import { skills } from "../../../../../mocks/fixtures";
+import { useProjection } from "../../../../../services/projection";
+import theme from "../../../../../theme";
+import TableRow from "./TableRow";
+describe("Pages/Dashboard/ReportTable/TableRow", () => {
+  it("renders the first TableRow component", async () => {
+      const {result} = renderHook(()=>useProjection(new Date(), skills));
+    render(
+        <MemoryRouter>
+            <StylesProvider value={theme}>
+                <table>
+                    <TableRow skill={skills[0]} projections={result.current.skillsWithProjection[0].projections} />
+                </table>
+            </StylesProvider>
+        </MemoryRouter>
+    );
+    expect(await screen.findByText(skills[0].name)).toBeInTheDocument();
+  });
+});

--- a/src/pages/Dashboard/components/ReportTable/TableRow/TableRow.tsx
+++ b/src/pages/Dashboard/components/ReportTable/TableRow/TableRow.tsx
@@ -165,7 +165,7 @@ function TableRow({ skill, projections }: TableRowProps): JSX.Element {
                     </Td>
                   );
                 } else {
-                  return null;
+                  return <td key={i}></td>;
                 }
               })}
             </Tr>

--- a/src/pages/Dashboard/components/ReportTable/TableRow/TableRow.tsx
+++ b/src/pages/Dashboard/components/ReportTable/TableRow/TableRow.tsx
@@ -165,7 +165,7 @@ function TableRow({ skill, projections }: TableRowProps): JSX.Element {
                     </Td>
                   );
                 } else {
-                  return <td key={i}></td>;
+                  return <Td key={i}></Td>;
                 }
               })}
             </Tr>


### PR DESCRIPTION
- Fixed issue where 'Needed' rows were not properly aligned with their column headers. This was because we were returning null as table data causing columns in the next row to be in the wrong table header
- Fixed issue with 'ReportTable' details not rendering in storybook due to a missing router
- Added simple render test to 'TableRow' component

https://bitovi.atlassian.net/browse/STAF-304