### PR TITLE
updated roles text to skills where referring to a speciic skill inste…

### DIFF
--- a/src/pages/Employees/components/EmployeeModal/EmployeeModal.tsx
+++ b/src/pages/Employees/components/EmployeeModal/EmployeeModal.tsx
@@ -239,7 +239,7 @@ export default function EmployeeModal({
             </HStack>
 
             <FormControl>
-              <FormLabel>Roles</FormLabel>
+              <FormLabel>Skills</FormLabel>
               <Flex mt={4} flexGrow={1}>
                 <SimpleGrid columns={2} spacingX={24} spacingY={4}>
                   {skills?.map((skill) => (

--- a/src/pages/Projects/components/RoleModal/RoleModal.test.tsx
+++ b/src/pages/Projects/components/RoleModal/RoleModal.test.tsx
@@ -374,7 +374,7 @@ describe("Pages/Projects/components/RoleModal", () => {
     );
 
     // Make sure we don't show skills selection in edit mode
-    expect(queryByText(/Select Role/g)).not.toBeInTheDocument();
+    expect(queryByText(/Select Skill/g)).not.toBeInTheDocument();
     expect(queryByRole("radio")).not.toBeInTheDocument();
 
     // make sure inputs are prefilled with role to edit data

--- a/src/pages/Projects/components/RoleModal/RoleModal.tsx
+++ b/src/pages/Projects/components/RoleModal/RoleModal.tsx
@@ -490,7 +490,7 @@ export default function RoleModal({
               </Heading>
             ) : (
               <FormControl>
-                <FormLabel>Select Role</FormLabel>
+                <FormLabel>Select Skill</FormLabel>
                 <Controller
                   control={control}
                   name="skillId"


### PR DESCRIPTION
- Updated 'Role' text to say 'Skill' where appropriate (it was using role to refer to a specific skill before)
- https://bitovi.atlassian.net/browse/STAF-298