### PR TITLE
updated need calculation to account for ending in the middle of the week

### DIFF
--- a/src/services/projection/projections/needed.ts
+++ b/src/services/projection/projections/needed.ts
@@ -129,13 +129,13 @@ export const calculateNeededForSkillForPeriod = (
             }
           }
 
-          // If there is no assignment for this day, the needed value is the role's start confidence
-          // if the role is over though then the needed value is the end confidence
+          // If the role is over then the needed value is the end confidence
           if (role.endDate && j >= role.endDate) {
             arrayOfDays[arrayOfDaysIndex].days.push(
               role.endConfidence ? 1 - role.endConfidence : 0,
             );
           } else {
+            // If there is no assignment for this day, the needed value is the role's start confidence
             arrayOfDays[arrayOfDaysIndex].days.push(role.startConfidence);
           }
         }

--- a/src/services/projection/projections/needed.ts
+++ b/src/services/projection/projections/needed.ts
@@ -130,7 +130,14 @@ export const calculateNeededForSkillForPeriod = (
           }
 
           // If there is no assignment for this day, the needed value is the role's start confidence
-          arrayOfDays[arrayOfDaysIndex].days.push(role.startConfidence);
+          // if the role is over though then the needed value is the end confidence
+          if (role.endDate && j >= role.endDate) {
+            arrayOfDays[arrayOfDaysIndex].days.push(
+              role.endConfidence ? 1 - role.endConfidence : 0,
+            );
+          } else {
+            arrayOfDays[arrayOfDaysIndex].days.push(role.startConfidence);
+          }
         }
       } else {
         // Similarly, if the role has no assignments, all days of this period will have a needed value

--- a/src/services/projection/projections/needed.ts
+++ b/src/services/projection/projections/needed.ts
@@ -130,7 +130,7 @@ export const calculateNeededForSkillForPeriod = (
           }
 
           // If there is no assignment for this day, the needed value is the role's start confidence
-          // if the role is over though then the needed value is the end confidence
+          // if the role is over though then the needed value is the end confidence 
           if (role.endDate && j >= role.endDate) {
             arrayOfDays[arrayOfDaysIndex].days.push(
               role.endConfidence ? 1 - role.endConfidence : 0,

--- a/src/services/projection/projections/needed.ts
+++ b/src/services/projection/projections/needed.ts
@@ -130,7 +130,7 @@ export const calculateNeededForSkillForPeriod = (
           }
 
           // If there is no assignment for this day, the needed value is the role's start confidence
-          // if the role is over though then the needed value is the end confidence 
+          // if the role is over though then the needed value is the end confidence
           if (role.endDate && j >= role.endDate) {
             arrayOfDays[arrayOfDaysIndex].days.push(
               role.endConfidence ? 1 - role.endConfidence : 0,

--- a/src/services/projection/projections/projectionStories/projections.stories.tsx
+++ b/src/services/projection/projections/projectionStories/projections.stories.tsx
@@ -584,6 +584,68 @@ NeededUseCase7.parameters = {
   controls: { hideNoControlsWarning: true },
 };
 
+export const NeededUseCase8: ComponentStory<typeof ProjectionsContainer> =
+  () => {
+    const dashboardStart = new Date(2018, 0, 1);
+    const skill = { id: "1001", name: "React" };
+    const role = {
+      id: "1",
+      startDate: new Date(2018, 0, 1),
+      startConfidence: 1,
+      endDate: new Date(2018, 0, 10),
+      endConfidence: 0.8,
+      project: projects[0],
+      skills: [skill],
+    };
+
+    const employee = {
+      id: "20",
+      name: "John Doe",
+      skills: [skill],
+    };
+    const roles = [
+      {
+        ...role,
+        assignments: [
+          {
+            id: "2",
+            employee,
+            role,
+            startDate: new Date(2018, 0, 1),
+            endDate: new Date(2018, 0, 10),
+          },
+        ],
+      },
+    ];
+
+    const skillsWithRoles = [
+      {
+        ...skill,
+        roles,
+      },
+    ];
+
+    const { skillsWithProjection } = useProjection(
+      dashboardStart,
+      skillsWithRoles,
+    );
+
+    const projections = skillsWithProjection[0].projections;
+    return (
+      <ProjectionsContainer
+        title="Role ends in the middle of a week"
+        dashboardStart={dashboardStart}
+        roles={roles}
+        skill={skill}
+        projections={projections}
+      />
+    );
+  };
+
+NeededUseCase8.parameters = {
+  controls: { hideNoControlsWarning: true },
+};
+
 export const BenchUseCase1: ComponentStory<typeof ProjectionsContainer> =
   () => {
     const dashboardStart = new Date(2018, 0, 1);


### PR DESCRIPTION
- Added a check for when a role ends in the middle of the week that will show the end confidence instead of 100% in the 'needed' part of the table
- https://bitovi.atlassian.net/browse/STAF-312