### PR TITLE
Staf 279 longer department badges are hard to read

### DIFF
--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -15,14 +15,17 @@ Small.args = {
 };
 
 export const SmallLongText: ComponentStory<typeof Badge> = ({ ...props }) => (
-  <Badge {...props}>Project Management. Lorem Ipsum is simply dummy text of the printing and 
-  typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s</Badge>
+  <Badge {...props}>
+    Project Management. Lorem Ipsum is simply dummy text of the printing and
+    typesetting industry. Lorem Ipsum has been the industrys standard dummy text
+    ever since the 1500s
+  </Badge>
 );
 
 SmallLongText.args = {
   size: "sm",
   isTruncated: false,
-  textAlign:'center'
+  textAlign: "center",
 };
 
 export const Medium: ComponentStory<typeof Badge> = ({ ...props }) => (

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -14,6 +14,25 @@ Small.args = {
   size: "sm",
 };
 
+export const SmallLongText: ComponentStory<typeof Badge> = ({ ...props }) => (
+  <Badge {...props}>Small With a lot of Text. Project Management</Badge>
+);
+
+SmallLongText.args = {
+  size: "sm",
+  isTruncated: false
+};
+
+export const SmallLongText80px: ComponentStory<typeof Badge> = ({ ...props }) => (
+  <Badge {...props}>Small With a lot of Text. Project Management</Badge>
+);
+
+SmallLongText80px.args = {
+  size: "sm",
+  isTruncated: false,
+  maxWidth:'80px'
+};
+
 export const Medium: ComponentStory<typeof Badge> = ({ ...props }) => (
   <Badge {...props}>Medium</Badge>
 );

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -21,7 +21,8 @@ export const SmallLongText: ComponentStory<typeof Badge> = ({ ...props }) => (
 
 SmallLongText.args = {
   size: "sm",
-  isTruncated: false
+  isTruncated: false,
+  textAlign:'center'
 };
 
 export const Medium: ComponentStory<typeof Badge> = ({ ...props }) => (

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -15,22 +15,13 @@ Small.args = {
 };
 
 export const SmallLongText: ComponentStory<typeof Badge> = ({ ...props }) => (
-  <Badge {...props}>Small With a lot of Text. Project Management</Badge>
+  <Badge {...props}>Project Management. Lorem Ipsum is simply dummy text of the printing and 
+  typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s</Badge>
 );
 
 SmallLongText.args = {
   size: "sm",
   isTruncated: false
-};
-
-export const SmallLongText80px: ComponentStory<typeof Badge> = ({ ...props }) => (
-  <Badge {...props}>Small With a lot of Text. Project Management</Badge>
-);
-
-SmallLongText80px.args = {
-  size: "sm",
-  isTruncated: false,
-  maxWidth:'80px'
 };
 
 export const Medium: ComponentStory<typeof Badge> = ({ ...props }) => (

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -10,6 +10,7 @@ type BadgeProps = {
   children: React.ReactNode;
   whiteSpace?: TextProps["whiteSpace"];
   textAlign?: TextProps["textAlign"];
+  display?: TextProps['display'];
 };
 
 function Badge({
@@ -20,6 +21,7 @@ function Badge({
   isTruncated = true,
   whiteSpace = undefined,
   textAlign = undefined,
+  display = undefined
 }: BadgeProps): JSX.Element {
   return (
     <ChakraTag bg={background} variant="solid" color="white" size={size}>
@@ -28,6 +30,7 @@ function Badge({
         isTruncated={isTruncated}
         whiteSpace={whiteSpace}
         maxWidth={maxWidth || "200px"}
+        display={display}
       >
         {children}
       </Text>

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -6,24 +6,29 @@ type BadgeProps = {
   size: "sm" | "md" | "lg";
   maxWidth?: string;
   background?: string;
-  isTruncated?:boolean;
+  isTruncated?: boolean;
   children: React.ReactNode;
-  whiteSpace?: TextProps['whiteSpace'];
-  textAlign?: TextProps['textAlign'];
-} ;
+  whiteSpace?: TextProps["whiteSpace"];
+  textAlign?: TextProps["textAlign"];
+};
 
 function Badge({
   background,
   size,
   maxWidth,
   children,
-  isTruncated=true,
-  whiteSpace=undefined,
-  textAlign=undefined
+  isTruncated = true,
+  whiteSpace = undefined,
+  textAlign = undefined,
 }: BadgeProps): JSX.Element {
   return (
     <ChakraTag bg={background} variant="solid" color="white" size={size}>
-      <Text textAlign={textAlign} isTruncated={isTruncated} whiteSpace={whiteSpace} maxWidth={maxWidth || "200px"}>
+      <Text
+        textAlign={textAlign}
+        isTruncated={isTruncated}
+        whiteSpace={whiteSpace}
+        maxWidth={maxWidth || "200px"}
+      >
         {children}
       </Text>
     </ChakraTag>

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,23 +1,29 @@
 import React from "react";
 import { Tag as ChakraTag } from "@chakra-ui/tag";
-import { Text } from "@chakra-ui/react";
+import { Text, TextProps } from "@chakra-ui/react";
 
 type BadgeProps = {
   size: "sm" | "md" | "lg";
-  background?: string;
   maxWidth?: string;
+  background?: string;
+  isTruncated?:boolean;
   children: React.ReactNode;
-};
+  whiteSpace?: TextProps['whiteSpace'];
+  hyphens?: "none" | "manual" | "auto";// chakra text does not support hyphens prop
+} ;
 
 function Badge({
   background,
   size,
   maxWidth,
   children,
+  isTruncated=true,
+  whiteSpace=undefined,
+  hyphens=undefined
 }: BadgeProps): JSX.Element {
   return (
     <ChakraTag bg={background} variant="solid" color="white" size={size}>
-      <Text isTruncated maxWidth={maxWidth || "95px"}>
+      <Text style={{ hyphens: hyphens }} textAlign='center' isTruncated={isTruncated} whiteSpace={whiteSpace} maxWidth={maxWidth || "200px"}>
         {children}
       </Text>
     </ChakraTag>

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -9,6 +9,7 @@ type BadgeProps = {
   isTruncated?:boolean;
   children: React.ReactNode;
   whiteSpace?: TextProps['whiteSpace'];
+  textAlign?: TextProps['textAlign'];
 } ;
 
 function Badge({
@@ -17,11 +18,12 @@ function Badge({
   maxWidth,
   children,
   isTruncated=true,
-  whiteSpace=undefined
+  whiteSpace=undefined,
+  textAlign=undefined
 }: BadgeProps): JSX.Element {
   return (
     <ChakraTag bg={background} variant="solid" color="white" size={size}>
-      <Text textAlign='center' width='80px' isTruncated={isTruncated} whiteSpace={whiteSpace} maxWidth={maxWidth || "200px"}>
+      <Text textAlign={textAlign} isTruncated={isTruncated} whiteSpace={whiteSpace} maxWidth={maxWidth || "200px"}>
         {children}
       </Text>
     </ChakraTag>

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -10,7 +10,7 @@ type BadgeProps = {
   children: React.ReactNode;
   whiteSpace?: TextProps["whiteSpace"];
   textAlign?: TextProps["textAlign"];
-  display?: TextProps['display'];
+  display?: TextProps["display"];
 };
 
 function Badge({
@@ -21,7 +21,7 @@ function Badge({
   isTruncated = true,
   whiteSpace = undefined,
   textAlign = undefined,
-  display = undefined
+  display = undefined,
 }: BadgeProps): JSX.Element {
   return (
     <ChakraTag bg={background} variant="solid" color="white" size={size}>

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -9,7 +9,6 @@ type BadgeProps = {
   isTruncated?:boolean;
   children: React.ReactNode;
   whiteSpace?: TextProps['whiteSpace'];
-  hyphens?: "none" | "manual" | "auto";// chakra text does not support hyphens prop
 } ;
 
 function Badge({
@@ -18,12 +17,11 @@ function Badge({
   maxWidth,
   children,
   isTruncated=true,
-  whiteSpace=undefined,
-  hyphens=undefined
+  whiteSpace=undefined
 }: BadgeProps): JSX.Element {
   return (
     <ChakraTag bg={background} variant="solid" color="white" size={size}>
-      <Text style={{ hyphens: hyphens }} textAlign='center' isTruncated={isTruncated} whiteSpace={whiteSpace} maxWidth={maxWidth || "200px"}>
+      <Text textAlign='center' width='80px' isTruncated={isTruncated} whiteSpace={whiteSpace} maxWidth={maxWidth || "200px"}>
         {children}
       </Text>
     </ChakraTag>

--- a/src/pages/Dashboard/components/ReportTable/TableHeader/TableHeader.tsx
+++ b/src/pages/Dashboard/components/ReportTable/TableHeader/TableHeader.tsx
@@ -21,7 +21,7 @@ export default function TableHeader({
           color="#333333"
           fontWeight="700"
           letterSpacing="0.05em"
-          width="6rem"
+          width="7rem"
         >
           {columnLabel && (
             <Text textStyle="tableHead" fontSize="12px">

--- a/src/pages/Dashboard/components/ReportTable/TableRow/TableRow.tsx
+++ b/src/pages/Dashboard/components/ReportTable/TableRow/TableRow.tsx
@@ -95,6 +95,7 @@ function TableRow({ skill, projections }: TableRowProps): JSX.Element {
                 whiteSpace='break-spaces'
                 background={skillBackgrounds[skill.name]}
                 maxWidth="80px"
+                textAlign='center'
               >
                 {skill.name}
               </Badge>

--- a/src/pages/Dashboard/components/ReportTable/TableRow/TableRow.tsx
+++ b/src/pages/Dashboard/components/ReportTable/TableRow/TableRow.tsx
@@ -94,8 +94,9 @@ function TableRow({ skill, projections }: TableRowProps): JSX.Element {
                 size="sm"
                 whiteSpace="break-spaces"
                 background={skillBackgrounds[skill.name]}
-                maxWidth="80px"
+                maxWidth="100px"
                 textAlign="center"
+                display="flex"
               >
                 {skill.name}
               </Badge>

--- a/src/pages/Dashboard/components/ReportTable/TableRow/TableRow.tsx
+++ b/src/pages/Dashboard/components/ReportTable/TableRow/TableRow.tsx
@@ -92,10 +92,10 @@ function TableRow({ skill, projections }: TableRowProps): JSX.Element {
               <Badge
                 isTruncated={false}
                 size="sm"
-                whiteSpace='break-spaces'
+                whiteSpace="break-spaces"
                 background={skillBackgrounds[skill.name]}
                 maxWidth="80px"
-                textAlign='center'
+                textAlign="center"
               >
                 {skill.name}
               </Badge>

--- a/src/pages/Dashboard/components/ReportTable/TableRow/TableRow.tsx
+++ b/src/pages/Dashboard/components/ReportTable/TableRow/TableRow.tsx
@@ -95,7 +95,6 @@ function TableRow({ skill, projections }: TableRowProps): JSX.Element {
                 whiteSpace='break-spaces'
                 background={skillBackgrounds[skill.name]}
                 maxWidth="80px"
-                hyphens='auto'
               >
                 {skill.name}
               </Badge>

--- a/src/pages/Dashboard/components/ReportTable/TableRow/TableRow.tsx
+++ b/src/pages/Dashboard/components/ReportTable/TableRow/TableRow.tsx
@@ -85,15 +85,17 @@ function TableRow({ skill, projections }: TableRowProps): JSX.Element {
         <Th
           rowSpan={isExpanded ? 3 + maxNeededRoles + maxBenchEmployees : 3}
           textTransform="none"
-          _before={{ content: "''", height: "15px", display: "block" }}
           borderRadius="8px"
         >
           <Center px={3}>
             <Flex flex={1} ml={1}>
               <Badge
+                isTruncated={false}
                 size="sm"
+                whiteSpace='break-spaces'
                 background={skillBackgrounds[skill.name]}
-                maxWidth="70px"
+                maxWidth="80px"
+                hyphens='auto'
               >
                 {skill.name}
               </Badge>
@@ -165,7 +167,7 @@ function TableRow({ skill, projections }: TableRowProps): JSX.Element {
                     </Td>
                   );
                 } else {
-                  return null;
+                  return <Td key={i}></Td>;
                 }
               })}
             </Tr>


### PR DESCRIPTION
- https://bitovi.atlassian.net/browse/STAF-279
- Added flex to the text itself to avoid word breaks as suggested
- increased table header width to show badges with longer words while keeping the table header width fixed to allow for the rest of the table to be flexible