### PR TITLE
fix: (STAF-356) update the Date references used on front end

### DIFF
--- a/src/pages/Employees/components/EmployeeModal/EmployeeModal.tsx
+++ b/src/pages/Employees/components/EmployeeModal/EmployeeModal.tsx
@@ -27,7 +27,6 @@ import { Button } from "@chakra-ui/button";
 import { useForm, Controller } from "react-hook-form";
 import { isEmpty, pickBy } from "lodash";
 import formatISO from "date-fns/formatISO";
-import parseISO from "date-fns/parseISO";
 
 import { formatDateToUTC } from "../../../../services/helpers/utcdate";
 import { Employee, Skill } from "../../../../services/api";
@@ -127,13 +126,12 @@ export default function EmployeeModal({
   const submitForm = async (data: EmployeeFormData) => {
     if (canSubmitForm) {
       const employeeSkills = getSelectedSkills(data.skills, skills || []);
-
       try {
         setStatus("pending");
         await onSave({
           name: data.name,
-          startDate: data.startDate ? parseISO(data.startDate) : null,
-          endDate: data.endDate ? parseISO(data.endDate) : null,
+          startDate: data.startDate ? data.startDate : null,
+          endDate: data.endDate ? data.endDate : null,
           skills: employeeSkills,
         });
         reset({ name: "", startDate: "", endDate: "" });

--- a/src/pages/Projects/components/RoleCard/RoleCard.tsx
+++ b/src/pages/Projects/components/RoleCard/RoleCard.tsx
@@ -1,6 +1,7 @@
 import type { Assignment, Role } from "../../../../services/api";
 import { Flex, IconButton, Wrap, Td, Tr, Text } from "@chakra-ui/react";
 import { format } from "date-fns";
+import { formatDateToUTC } from "../../../../services/helpers/utcdate";
 import Badge from "../../../../components/Badge";
 import { TrashIcon, EditIcon } from "../../../assets";
 
@@ -64,7 +65,7 @@ export default function RoleCard({
             lineHeight="20px"
             letterSpacing="0.25px"
           >
-            {format(role.startDate, "MM/dd/yyyy")}
+            {format(formatDateToUTC(role.startDate), "MM/dd/yyyy")}
           </Text>
         </Td>
         <Td>
@@ -86,7 +87,8 @@ export default function RoleCard({
             lineHeight="20px"
             letterSpacing="0.25px"
           >
-            {role.endDate && format(role.endDate, "MM/dd/yyyy")}
+            {role.endDate &&
+              format(formatDateToUTC(role.endDate), "MM/dd/yyyy")}
           </Text>
         </Td>
         <Td>

--- a/src/pages/Projects/components/RoleDate/RoleDate.tsx
+++ b/src/pages/Projects/components/RoleDate/RoleDate.tsx
@@ -10,7 +10,7 @@ export default function RoleDate({
   onDateChange,
 }: {
   title: "Start Date" | "End Date";
-  date: Date | undefined;
+  date: Date | string | undefined;
   confidence: number | undefined;
   onConfidenceChange: (confidence?: number) => void;
   onDateChange: (date?: Date) => void;

--- a/src/pages/Projects/components/RoleModal/RoleModal.tsx
+++ b/src/pages/Projects/components/RoleModal/RoleModal.tsx
@@ -134,7 +134,7 @@ export default function RoleModal({
     assignments: [],
   };
 
-  const formatDate = (date: Date) => {
+  const formatDate = (date: Date | string) => {
     return formatISO(formatDateToUTC(date)).substring(0, 10);
   };
 
@@ -381,9 +381,9 @@ export default function RoleModal({
         const newRole = {
           project: omit(project, ["roles"]),
           skills: skills.filter((skill) => skill.id === data.skillId),
-          startDate: parseISO(data.startDate),
+          startDate: data.startDate,
           startConfidence: data.startConfidence || 1,
-          endDate: data.endDate ? parseISO(data.endDate) : null,
+          endDate: data.endDate ? data.endDate : null,
           ...(!data.endConfidence && data.endConfidence !== 0
             ? { endConfidence: undefined }
             : { endConfidence: Number(data.endConfidence) }),
@@ -448,9 +448,9 @@ export default function RoleModal({
           {
             project: omit(project, ["roles"]),
             skills: roleToEdit.skills,
-            startDate: parseISO(data.startDate),
+            startDate: data.startDate,
             startConfidence: data.startConfidence || 1,
-            endDate: data.endDate ? parseISO(data.endDate) : null,
+            endDate: data.endDate ? data.endDate : null,
             ...(!data.endConfidence && data.endConfidence !== 0
               ? { endConfidence: undefined }
               : { endConfidence: Number(data.endConfidence) }),

--- a/src/services/api/Assignments/Assignments.ts
+++ b/src/services/api/Assignments/Assignments.ts
@@ -8,7 +8,6 @@ export interface Assignment extends BaseData {
   id: string;
   startDate: Date;
   endDate?: Date | null;
-
   employee: Employee;
   role: Role;
 }

--- a/src/services/api/Employees/Employees.ts
+++ b/src/services/api/Employees/Employees.ts
@@ -7,14 +7,12 @@ import { Skill } from "../Skills";
 export interface Employee extends BaseData {
   id: string;
   name: string;
-  startDate?: Date | null;
-  endDate?: Date | null;
+  startDate?: Date | string | null;
+  endDate?: Date | string | null;
 
   assignments?: Assignment[];
   skills: Skill[];
 }
-
-export type NewEmployee = Partial<Omit<Employee, "id">>;
 
 const { useRestOne, useRestList, useRestMutations } = restBuilder<Employee>(
   "/employees",

--- a/src/services/api/Roles/Roles.ts
+++ b/src/services/api/Roles/Roles.ts
@@ -7,9 +7,9 @@ import { Skill } from "../Skills";
 
 export interface Role extends BaseData {
   id: string;
-  startDate: Date;
+  startDate: Date | string;
   startConfidence: number;
-  endDate?: Date | null;
+  endDate?: Date | string | null;
   endConfidence?: number;
   assignments?: Assignment[];
   project: Project;

--- a/src/services/helpers/utcdate/utcdate.test.ts
+++ b/src/services/helpers/utcdate/utcdate.test.ts
@@ -17,6 +17,12 @@ describe("utcdate helper", () => {
       });
     });
   });
+  describe("when given a string as date", () => {
+    it("returns a the day of the same day", () => {
+      const result = formatDateToUTC("2022-06-14");
+      expect(result.getDate()).toBe(14);
+    });
+  });
 });
 
 export {};

--- a/src/services/helpers/utcdate/utcdate.ts
+++ b/src/services/helpers/utcdate/utcdate.ts
@@ -1,6 +1,18 @@
 //Currently using date-fns, which format function only accepts a Date or a number. I made this function to create a Date of the UTC from the original date.
-export const formatDateToUTC = (date: Date): Date => {
-  return new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+export const formatDateToUTC = (date: Date | string): Date => {
+  if (date instanceof Date) {
+    return new Date(
+      date.getUTCFullYear(),
+      date.getUTCMonth(),
+      date.getUTCDate(),
+    );
+  }
+  const localizedDate = new Date(date);
+  return new Date(
+    localizedDate.getUTCFullYear(),
+    localizedDate.getUTCMonth(),
+    localizedDate.getUTCDate(),
+  );
 };
 
 export default formatDateToUTC;

--- a/src/services/projection/projections/needed.ts
+++ b/src/services/projection/projections/needed.ts
@@ -80,13 +80,18 @@ export const calculateNeededForSkillForPeriod = (
     const arrayOfDaysIndex = i + prevRoleIndex;
 
     // We first check if the role happends during this time period
+    const startDateAsDate =
+      role.startDate instanceof Date
+        ? role.startDate
+        : new Date(role.startDate);
+    const endDateAsDate =
+      role.endDate instanceof Date
+        ? role.endDate
+        : role.endDate
+        ? new Date(role.startDate)
+        : undefined;
     if (
-      doDatesOverlap(
-        role.startDate,
-        role.endDate || undefined,
-        periodStart,
-        periodEnd,
-      )
+      doDatesOverlap(startDateAsDate, endDateAsDate, periodStart, periodEnd)
     ) {
       arrayOfDays[arrayOfDaysIndex] = {
         project: { name: role.project.name, id: role.project.id },
@@ -107,7 +112,12 @@ export const calculateNeededForSkillForPeriod = (
             // If the role ends with an end confidence of less than 1,
             // we add its end confidence so we can carry it to next periods
             if (
-              datesAreOnSameDay(j, role.endDate) &&
+              datesAreOnSameDay(
+                j,
+                role.endDate instanceof Date
+                  ? role.endDate
+                  : new Date(role.endDate),
+              ) &&
               role.endConfidence !== 1
             ) {
               // Unless the role has an associated assignment with no end date

--- a/src/services/projection/projections/projectionStories/LineChart.tsx
+++ b/src/services/projection/projections/projectionStories/LineChart.tsx
@@ -19,8 +19,14 @@ const LineChart = ({
   let duration = 0;
   let totalNumOfDays = 0;
 
-  const roleStart = data.startDate;
-  let roleEnd = data.endDate;
+  const roleStart =
+    data.startDate instanceof Date ? data.startDate : new Date(data.startDate);
+  let roleEnd =
+    data.endDate instanceof Date
+      ? data.endDate
+      : data.endDate
+      ? new Date(data.endDate)
+      : undefined;
 
   if (!roleEnd) {
     roleEnd = timeline[timeline.length - 1].endDate;

--- a/src/services/projection/projections/projectionStories/projections.stories.tsx
+++ b/src/services/projection/projections/projectionStories/projections.stories.tsx
@@ -16,6 +16,7 @@ import { Employee, Role, Skill } from "../../../api";
 import useProjection from "../../useProjection";
 import useTimeline from "../../useTimeline";
 import { Projection } from "../projections";
+import { formatDateToUTC } from "../../../helpers/utcdate";
 import LineChart from "./LineChart";
 
 interface ProjectionProps {
@@ -46,9 +47,10 @@ const ProjectionsContainer = ({
       <UnorderedList mb="1em" color="blue">
         {roles.map((role) => (
           <ListItem key={role.id}>
-            Role: {role.startConfidence * 100}% {role.startDate.toDateString()},{" "}
+            Role: {role.startConfidence * 100}%{" "}
+            {formatDateToUTC(role.startDate)},{" "}
             {role.endConfidence && role.endDate
-              ? `${role.endConfidence * 100}% ${role.endDate.toDateString()}`
+              ? `${role.endConfidence * 100}% ${formatDateToUTC(role.endDate)}`
               : "null"}
             <UnorderedList color="red">
               {role.assignments && role.assignments.length > 0 ? (


### PR DESCRIPTION

I neglected to catch every reference to the dates in the system, I've done more work for it to send it front the front end as intended as well as making sure each reference to Date | string has the appropriate logic to handle it.