### PR TITLE
fix: (STAF-405) add 404 not found page redirect for projects

### DIFF
--- a/src/components/ErrorBoundary/ErrorBondary.test.tsx
+++ b/src/components/ErrorBoundary/ErrorBondary.test.tsx
@@ -1,6 +1,8 @@
+import { BrowserRouter, Switch, Route } from "react-router-dom";
 import { render, screen } from "@testing-library/react";
 
 import ErrorBoundary from "./ErrorBoundary";
+import NotFound from "../../pages/NotFound";
 
 describe("Components/ErrorBoundary", () => {
   it("should show error message", () => {
@@ -33,5 +35,32 @@ describe("Components/ErrorBoundary", () => {
 
     const errorMessage = screen.getByText("Sorry... there was an error.");
     expect(errorMessage).toBeInTheDocument();
+  });
+
+  describe("should redirect to '404 Page Not Found", () => {
+    it("when error message contains 'An error occurred while fetching: GET /projects/'", () => {
+      const ProjectErrorComponent = () => {
+        throw new Error(
+          "An error occurred while fetching: GET /projects/ripproject",
+        );
+      };
+
+      const { getByText } = render(
+        <BrowserRouter>
+          <Switch>
+            <Route path="/" exact>
+              <ErrorBoundary>
+                <ProjectErrorComponent />
+              </ErrorBoundary>
+            </Route>
+            <Route>
+              <NotFound />
+            </Route>
+          </Switch>
+        </BrowserRouter>,
+      );
+
+      expect(getByText("404 PAGE NOT FOUND")).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React, { Component, ReactNode } from "react";
+import { Redirect } from "react-router-dom";
 import AlertBar from "../AlertBar";
 
 interface Props {
@@ -24,9 +25,17 @@ class ErrorBoundary extends Component<Props, State> {
   public render(): ReactNode {
     if (this.state.hasError) {
       if (this.state?.error?.message) {
-        return (
-          <AlertBar description={this.state.error.message} status="error" />
-        );
+        if (
+          this.state.error.message.includes(
+            "An error occurred while fetching: GET /projects/",
+          )
+        ) {
+          return <Redirect to="/404" />;
+        } else {
+          return (
+            <AlertBar description={this.state.error.message} status="error" />
+          );
+        }
       }
 
       return <h1>Sorry... there was an error.</h1>;


### PR DESCRIPTION
The app will now redirect to the 404 page when a project is not found, with the current design there's no need to have it redirect for the team member routes since they aren't navigated to by routes.