### PR TITLE
fix: (STAF-387) update tabs to be sticky

### DIFF
--- a/src/pages/Employees/Employees.tsx
+++ b/src/pages/Employees/Employees.tsx
@@ -124,20 +124,20 @@ export default function Employees({
               Add Team Member
             </Button>
           </Flex>
+          <TeamMemberTabs
+            onChange={({
+              active,
+              inactive,
+            }: {
+              active: boolean;
+              inactive: boolean;
+            }) => {
+              setShowActiveEmployees(active);
+              setShowInactiveEmployees(inactive);
+            }}
+            defaultIndex={tabIndex}
+          />
         </Box>
-        <TeamMemberTabs
-          onChange={({
-            active,
-            inactive,
-          }: {
-            active: boolean;
-            inactive: boolean;
-          }) => {
-            setShowActiveEmployees(active);
-            setShowInactiveEmployees(inactive);
-          }}
-          defaultIndex={tabIndex}
-        />
         <EmployeeTableWrapper
           mt="32px"
           updateEmployee={updateEmployee}

--- a/src/pages/Employees/components/EmployeeTable/components/EmployeeTableHeader/EmployeeTableHeader.tsx
+++ b/src/pages/Employees/components/EmployeeTable/components/EmployeeTableHeader/EmployeeTableHeader.tsx
@@ -3,7 +3,7 @@ import { chakra, Th, Tr } from "@chakra-ui/react";
 const StickyHeader = chakra(Th, {
   baseStyle: {
     position: "sticky",
-    top: "11em",
+    top: "15em",
     background: "gray.10",
     zIndex: "10",
   },


### PR DESCRIPTION
just moved the tabs into the Box of the page header while adjusting the top of the team member's header