### PR TITLE
Display errors from api in chakra error-style toast message

### DIFF
--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -3,3 +3,4 @@ export * from "./Employees";
 export * from "./Projects";
 export * from "./Roles";
 export * from "./Skills";
+export { HttpError } from "./restBuilder/fetcher";

--- a/src/services/api/restBuilder/fetcher/index.ts
+++ b/src/services/api/restBuilder/fetcher/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./fetcher";
+export { default, HttpError } from "./fetcher";


### PR DESCRIPTION
fix: (STAF-417) 


edit: [`Files Changed (4)`](https://github.com/bitovi/app-staffing/pull/350/files?w=1) compare is cleaner if you ignore whitespace