### PR TITLE
make project list subheader match style of subheader on dashboard

### DIFF
--- a/src/components/DataTable/DataTimelineHeader/DataTimelineHeader.tsx
+++ b/src/components/DataTable/DataTimelineHeader/DataTimelineHeader.tsx
@@ -51,7 +51,13 @@ function DataTimelineHeader({
               {/* Sub Heading */}
               <Center height={4} flex={1} justifyContent="start">
                 {(type === "month" || type === "quarter") && (
-                  <Text fontSize="12px" textAlign="center" color={"#718096"}>
+                  <Text
+                    fontSize="12px"
+                    fontWeight="700"
+                    textTransform="uppercase"
+                    textAlign="center"
+                    color={"#718096"}
+                  >
                     {format(formatDateToUTC(startDate), "MMM do")}
                   </Text>
                 )}


### PR DESCRIPTION
fix: (STAF-411) 

before:
<img width="1133" alt="image" src="https://user-images.githubusercontent.com/92131113/179818581-3c71f33c-487d-4072-9e82-3639321316fa.png">

after:
<img width="1165" alt="image" src="https://user-images.githubusercontent.com/92131113/179818524-a3f2ac3d-a6ae-4f32-8c3a-4f02e50d6734.png">
