### PR TITLE
make future bench values account for start confidence

### DIFF
--- a/src/services/projection/projections/bench.ts
+++ b/src/services/projection/projections/bench.ts
@@ -57,8 +57,8 @@ export function calculateBenchForSkillForPeriod(
         formatDateToUTC(employee.startDate) <= periodStart) &&
       (!employee.endDate || formatDateToUTC(employee.endDate) >= periodEnd)
     ) {
-      // If the employee has no assignments then he's on the bench
-      // If he has assignments, we check the dates
+      // If the employee has no assignments then they're on the bench
+      // If they have assignments, we check the dates
       if (
         Array.isArray(employee.assignments) &&
         employee.assignments.length > 0
@@ -76,16 +76,15 @@ export function calculateBenchForSkillForPeriod(
           index += 1;
           for (const assignment of orderedAssignments) {
             // The days when the employee is assigned
-            // The assignment has started and either it didn't end yet,
+            // The assignment didn't end yet,
             // or it doesnt have an end date and we check if the role has not ended yet
             // which means either the role end date is later than date j or that there is no end date
             if (
-              assignment.startDate <= j &&
-              (assignment.endDate
+              assignment.endDate
                 ? assignment.endDate >= j
                 : assignment.role.endDate
                 ? assignment.role.endDate >= j
-                : true)
+                : true
             ) {
               const benchValue = +(
                 (1 - assignment.role.startConfidence) /


### PR DESCRIPTION
fix: (STAF-363) 
https://bitovi.atlassian.net/browse/STAF-363

I don't have full confidence that this change is correct because of the complexity here, but it seems to fix the data... Just need careful consideration in review if you could, please, @cded

before:
<img width="1192" alt="image" src="https://user-images.githubusercontent.com/92131113/180259472-d5fef666-3b1d-4f7a-991d-afc256352ecb.png">

after: 
<img width="1191" alt="image" src="https://user-images.githubusercontent.com/92131113/180259366-40312bc9-c14b-41fc-b1c7-f91ec2c8c102.png">
