### PR TITLE
fix (STAF-182): vertically align modal to eliminate scrollbars unless needed

### DIFF
--- a/src/pages/Employees/components/EmployeeModal/EmployeeModal.tsx
+++ b/src/pages/Employees/components/EmployeeModal/EmployeeModal.tsx
@@ -164,7 +164,7 @@ export default function EmployeeModal({
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="md" variant="team_modal">
       <ModalOverlay />
-      <ModalContent mt="14vh">
+      <ModalContent margin="auto" alignSelf="center">
         <ModalHeader textStyle="modal.title" pt={6} pl={6}>
           {isNewEmployee ? "Add a New Team Member" : "Edit Team Member"}
         </ModalHeader>


### PR DESCRIPTION
For accessibility, it is recommended to block scrolling on the main document behind the modal and allow the modal to scroll as if it were the window so the context the user scrolls in doesn't change/is maximized.