### PR TITLE
Fix (Staf-179): button stuck in loading on request failure

### DIFF
--- a/src/pages/Employees/components/EmployeeModal/EmployeeModal.tsx
+++ b/src/pages/Employees/components/EmployeeModal/EmployeeModal.tsx
@@ -128,8 +128,8 @@ export default function EmployeeModal({
   const submitForm = async (data: EmployeeFormData) => {
     if (canSubmitForm) {
       const employeeSkills = getSelectedSkills(data.skills, skills || []);
+      setStatus("pending");
       try {
-        setStatus("pending");
         await onSave({
           name: data.name,
           startDate: data.startDate ? data.startDate : null,

--- a/src/pages/Employees/components/EmployeeModal/EmployeeModal.tsx
+++ b/src/pages/Employees/components/EmployeeModal/EmployeeModal.tsx
@@ -126,23 +126,25 @@ export default function EmployeeModal({
       (!isNewEmployee && formIsDirty && nameProvided(employeeName)));
 
   const submitForm = async (data: EmployeeFormData) => {
-    if (canSubmitForm) {
-      const employeeSkills = getSelectedSkills(data.skills, skills || []);
-      setStatus("pending");
-      try {
-        await onSave({
-          name: data.name,
-          startDate: data.startDate ? data.startDate : null,
-          endDate: data.endDate ? data.endDate : null,
-          skills: employeeSkills,
-        });
-        reset({ name: "", startDate: "", endDate: "" });
-        onClose();
-      } catch (e) {
-        setServerError(!serverError);
-      }
-      setStatus("idle");
+    if (!canSubmitForm) return;
+
+    setStatus("pending");
+
+    try {
+      await onSave({
+        name: data.name,
+        startDate: data.startDate ? data.startDate : null,
+        endDate: data.endDate ? data.endDate : null,
+        skills: getSelectedSkills(data.skills, skills || []),
+      });
+
+      reset({ name: "", startDate: "", endDate: "" });
+      onClose();
+    } catch (e) {
+      setServerError(!serverError);
     }
+
+    setStatus("idle");
   };
 
   const resetForm = () => {
@@ -355,9 +357,16 @@ function getSelectedSkills(roles: Record<string, boolean>, skills: Skill[]) {
   if (isEmpty(roles)) return [];
 
   const selected = pickBy(roles, (checked) => !!checked);
-  return Object.keys(selected).map(
-    (entry: string) => skills.find((skill) => skill.id === entry) as Skill,
-  );
+
+  return Object.keys(selected).map((skillID) => {
+    const temp = skills.find((skill) => skill.id === skillID);
+
+    if (!temp) {
+      throw new Error(`Could not find skill with ID ${skillID}`);
+    }
+
+    return { id: temp.id, name: temp.name };
+  });
 }
 
 function toEmployeeFormData(data: Employee): EmployeeFormData {

--- a/src/pages/Employees/components/EmployeeModal/EmployeeModal.tsx
+++ b/src/pages/Employees/components/EmployeeModal/EmployeeModal.tsx
@@ -138,10 +138,10 @@ export default function EmployeeModal({
         });
         reset({ name: "", startDate: "", endDate: "" });
         onClose();
-        setStatus("idle");
       } catch (e) {
         setServerError(!serverError);
       }
+      setStatus("idle");
     }
   };
 


### PR DESCRIPTION
When submitting a request to update an employee if the request failed the submit button was stuck in the loading state. There is also a fix for the logic when coming from the dashboard page extra data would be cached and cause the request to fail, so filtering was added to only submit the data needed.