### PR TITLE
Added fix for button state getting stuck

### DIFF
--- a/src/pages/Employees/components/EmployeeModal/EmployeeModal.tsx
+++ b/src/pages/Employees/components/EmployeeModal/EmployeeModal.tsx
@@ -70,7 +70,7 @@ export default function EmployeeModal({
     clearErrors,
     getValues,
     trigger,
-    formState: { errors, isDirty: formIsDirty },
+    formState: { errors, isDirty: formIsDirty, dirtyFields },
   } = useForm<EmployeeFormData>({
     defaultValues: employeeData,
   });
@@ -149,7 +149,10 @@ export default function EmployeeModal({
     !isStartDateInvalid &&
     !isEndDateInvalid &&
     ((isNewEmployee && nameProvided(employeeName)) ||
-      (!isNewEmployee && formIsDirty && nameProvided(employeeName)));
+      (!isNewEmployee &&
+        formIsDirty &&
+        !isEmpty(dirtyFields) &&
+        nameProvided(employeeName)));
 
   const submitForm = async (data: EmployeeFormData) => {
     if (!canSubmitForm) return;


### PR DESCRIPTION
When editing an employee if the information was changed and then reverted back to the original values the save button would remain enabled, this no longer the case and the button will disable since there is no changes to be saved