### PR TITLE
STAF-296: add query to SWR key

### DIFF
--- a/src/pages/Employees/components/EmployeeModal/components/EmployeeModalSkillsCard/EmployeeModalSkillsCard.tsx
+++ b/src/pages/Employees/components/EmployeeModal/components/EmployeeModalSkillsCard/EmployeeModalSkillsCard.tsx
@@ -24,9 +24,7 @@ export default function EmployeeModalSkillsCard({
   const skillsFetched = useSkills();
 
   useEffect(() => {
-    if (!skills.length && skillsFetched.length) {
-      setSkills(skillsFetched);
-    }
+    setSkills(skillsFetched);
   }, [skillsFetched?.length, skills?.length, setSkills, skillsFetched]);
 
   return (

--- a/src/pages/Projects/components/RoleList/RoleList.tsx
+++ b/src/pages/Projects/components/RoleList/RoleList.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import isEmpty from "lodash/isEmpty";
-import omit from "lodash/omit";
 import { Box, chakra, Table, Tbody, Th, Thead, Tr } from "@chakra-ui/react";
 import DeleteRoleModal from "../DeleteRoleModal";
 import RoleCard from "../RoleCard";
@@ -21,14 +20,7 @@ interface RoleListProps {
 }
 
 export default function RoleList({ project }: RoleListProps): JSX.Element {
-  const skillsWithEmployees = useSkills({
-    include: [
-      "employees.skills",
-      "employees.assignments.role.skills",
-      "employees.assignments.role.project",
-    ],
-  });
-  const skills = skillsWithEmployees.map((skill) => omit(skill, ["employees"]));
+  const skills = useSkills();
   const employees: Employee[] = useEmployees({ include: "skills" });
 
   const { createRole, updateRole, destroyRole } = useRoleMutations();

--- a/src/services/api/restBuilder/restBuilder.ts
+++ b/src/services/api/restBuilder/restBuilder.ts
@@ -54,7 +54,7 @@ export default function restBuilder<Data extends BaseData>(
 } {
   function useRestList(query?: ListQuery<Data>): Data[] {
     const { data, error } = useSWR<Data[], Error>(
-      path,
+      [path, JSON.stringify(query)],
       async (path) => {
         const response = await fetcher<JSONAPIDocument>(
           "GET",


### PR DESCRIPTION
SWR supports using an array as the key parameter that controls the cache (https://swr.vercel.app/docs/arguments). Adding the query as a second parameter allows us then to always have accurate requests. We pass it as a string as it's originally an array and comparison doesn't work.